### PR TITLE
Added SystemField.

### DIFF
--- a/ldapper/fields.py
+++ b/ldapper/fields.py
@@ -32,6 +32,10 @@ class Field(object):
       * should not appear in diff() results
     """
 
+    # System attributes are properties managed by the LDAP that cannot be
+    # set by the user.  Things like createTimestamp, modifiedTimestamp
+    system = False
+
     def __init__(self, ldap, optional=False, readonly=False, printable=True,
                  primary=False):
         """
@@ -178,3 +182,14 @@ class BinaryField(Field):
 
     def sanitize_for_ldap(self, val):
         return val
+
+
+class SystemField(Field):
+    """
+    Meant for ldap attributes that are system-managed by the LDAP server.
+    """
+
+    system = True
+
+    def sanitize_for_ldap(self, val):
+        raise Exception('This Field may not be written to the LDAP')


### PR DESCRIPTION
This new field type replaces supplemental attributes.  SystemFields can be
added to an LDAPNode just like any other field now.  They cannot be saved
back to the LDAP because they are supposed to represent fields that are
managed by the LDAP like createTimestamp, modifyTimestamp, creatorsName,
and modifiersName.

Resolves #5