### PR TITLE
Add Query objects to construct arbitrarily complex filters.

### DIFF
--- a/docs/apipages/query.rst
+++ b/docs/apipages/query.rst
@@ -1,0 +1,6 @@
+ldapper.query
+=============
+
+.. automodule:: ldapper.query
+   :members:
+   :undoc-members:

--- a/docs/ldapper/advanced-topics.rst
+++ b/docs/ldapper/advanced-topics.rst
@@ -1,3 +1,57 @@
 Advanced Topics
 ===============
 
+Complex Queries
+---------------
+
+ldapper has rich support for building arbitrarily complex filter queries.
+Similar to how Django does this, there is a :class:`~ldapper.query.Q` class
+that is the building block of queries.  Q objects can be strung together to
+build any boolean query imaginable.
+
+The simplest query we could build would be a single condition:
+
+.. code-block:: python
+
+   from ldapper.query import Q
+
+   Person.filter(
+       Q(employeetype='Director')
+   )
+
+This will return all the Person objects where employeetype is equal to
+director.  The cool thing here is that when the Q object was compiled down, it
+figured out what the ldap field names on Person were to build the filter.
+
+We can see that here:
+
+.. code-block:: python
+
+   >>> Q(employeetype='Director').compile(Person)
+   '(employeeType=Director)'
+
+Let's do something more interesting.  Let's return all of the people who
+are directors with either the first name "Bob" or "Mary".
+
+We would query for those people like this:
+
+.. code-block:: python
+
+   Person.filter(
+      Q(employeetype='Director') & (Q(firstname='Bob') | Q(firstname='Mary'))
+   )
+
+.. note::
+
+   Normal `operator precedence <https://docs.python.org/3/reference/expressions.html#operator-precedence>`_ rules in Python apply concerning ``&``, ``|``, and parentheses.
+
+Q objects can also contain multiple conditions.  They will all have to match.
+
+.. code-block:: python
+
+   Person.filter(
+      Q(firstname='Bob', lastname='Smith')
+   )
+
+And of course if you turn logging up to DEBUG levels, you can inspect the
+actual filters that are being generated to return results.

--- a/docs/ldapper/hooks.rst
+++ b/docs/ldapper/hooks.rst
@@ -1,7 +1,7 @@
 .. _hooks:
 
 Hooks/Callbacks
-===================
+===============
 
 There are four callbacks that can be overridden to perform an action before
 or after and object is added or deleted.
@@ -24,11 +24,11 @@ or after and object is added or deleted.
          self.logger.info('Being called after delete.')
 
 _before_add_callback
-----------
+--------------------
 Gets called just before the LDAPNode is added to the LDAP.
 
 _after_add_callback
-----------
+-------------------
 Gets called just after the LDAPNode is added to the LDAP.
 
 .. note::
@@ -37,9 +37,9 @@ Gets called just after the LDAPNode is added to the LDAP.
    are only called when saving a new object, not when saving existing objects.
 
 _before_delete_callback
-----------
+-----------------------
 Gets called just before the LDAPNode is deleted from the LDAP.
 
 _after_delete_callback
-----------
+----------------------
 Gets called just after the LDAPNode is deleted from the LDAP.

--- a/ldapper/ldapnode.py
+++ b/ldapper/ldapnode.py
@@ -647,6 +647,11 @@ class LDAPNode(object, metaclass=LDAPNodeBase):
             self.log__delete_failure()
 
     @classmethod
+    def filter(cls, q):
+        """Return a list of LDAPNodes filter based on the given Q object(s)"""
+        return cls.list(filter=q.compile(cls))
+
+    @classmethod
     def list(cls, filter=None, prefix=None, rdn_substring=None,
              search_prefix=None, search_string=None, dnprefix=None,
              max_results=None, **kwargs):

--- a/ldapper/query.py
+++ b/ldapper/query.py
@@ -1,0 +1,49 @@
+
+class Q(object):
+    """Query class"""
+
+    def __init__(self, **conditions):
+        self.conditions = conditions.items()
+
+        # children
+        self.AND = []
+        self.OR = []
+
+    def compile(self, cls):
+        immediate_filter = ''
+        for cond_k, cond_v in self.conditions:
+            attrname = cls._fields.get(cond_k).ldap
+            immediate_filter += f'({attrname}={cond_v})'
+        if len(self.conditions) > 1:
+            immediate_filter = f'(&{immediate_filter})'
+
+        or_filter = ''
+        for q in self.OR:
+            or_filter += q.compile(cls)
+        if len(self.OR) > 1:
+            or_filter = f'(|{or_filter})'
+
+        and_filter = ''
+        for q in self.AND:
+            and_filter += q.compile(cls)
+        if len(self.AND) > 1:
+            and_filter = f'(&{and_filter})'
+
+        if and_filter and or_filter:
+            return f'(&(|{immediate_filter}{or_filter}){and_filter})'
+        elif or_filter:
+            return f'(|{immediate_filter}{or_filter})'
+        elif and_filter:
+            return f'(&{immediate_filter}{and_filter})'
+        else:
+            return immediate_filter
+
+    def __and__(self, other):
+        # check that other is of the right type
+        self.AND.append(other)
+        return self
+
+    def __or__(self, other):
+        # check that other is of the right type
+        self.OR.append(other)
+        return self

--- a/ldapper/query.py
+++ b/ldapper/query.py
@@ -13,10 +13,6 @@ class Q(object):
     def __init__(self, **conditions):
         self.conditions = conditions.items()
 
-        # children
-        self.AND = []
-        self.OR = []
-
     def compile(self, cls):
         immediate_filter = ''
         for cond_k, cond_v in self.conditions:
@@ -27,38 +23,78 @@ class Q(object):
                     f'{cond_k} is not a valid field on {cls.__name__}: '
                     f'Expected: {list(cls._fields.keys())}')
             immediate_filter += f'({attrname}={cond_v})'
+
         if len(self.conditions) > 1:
             immediate_filter = f'(&{immediate_filter})'
 
-        or_filter = ''
-        for q in self.OR:
-            or_filter += q.compile(cls)
-        if len(self.OR) > 1:
-            or_filter = f'(|{or_filter})'
+        return immediate_filter
 
-        and_filter = ''
-        for q in self.AND:
-            and_filter += q.compile(cls)
-        if len(self.AND) > 1:
-            and_filter = f'(&{and_filter})'
-
-        if and_filter and or_filter:
-            return f'(&(|{immediate_filter}{or_filter}){and_filter})'
-        elif or_filter:
-            return f'(|{immediate_filter}{or_filter})'
-        elif and_filter:
-            return f'(&{immediate_filter}{and_filter})'
-        else:
-            return immediate_filter
-
-    def __and__(self, other):
+    def check_type_compat(self, other):
         if not isinstance(other, Q):
             raise TypeError(f'not of type Q: {other}')
-        self.AND.append(other)
-        return self
 
     def __or__(self, other):
-        if not isinstance(other, Q):
-            raise TypeError(f'not of type Q: {other}')
-        self.OR.append(other)
-        return self
+        self.check_type_compat(other)
+        if isinstance(other, Or):
+            other.ops.insert(0, self)
+            return other
+        else:
+            return Or([self, other])
+
+    def __and__(self, other):
+        self.check_type_compat(other)
+        if isinstance(other, And):
+            other.ops.insert(0, self)
+            return other
+        else:
+            return And([self, other])
+
+
+class And(Q):
+
+    def __init__(self, ops):
+        self.ops = ops
+
+    def compile(self, cls):
+        f = ''
+        for op in self.ops:
+            f += op.compile(cls)
+        return f'(&{f})'
+
+    def __and__(self, other):
+        if type(other) is Q:  # And(...) & Q(...)
+            # we repack Q(...) objects into one Q() object for each condition.
+            # This is so that:
+            #   (Q(lastname='Lennon') & Q(lastname='McCartney')) & \
+            #       Q(firstname='Ringo', lastname='Starr')
+            # Compiles to: (&(sn=Lennon)(sn=McCartney)(givenName=Ringo)(sn=Starr))
+            # And not:     (&(sn=Lennon)(sn=McCartney)(&(givenName=Ringo)(sn=Starr)))
+            self.ops.extend([Q(**{k: v}) for k, v in other.conditions])
+            return self
+        elif type(other) is And:  # And(...) & And(...)
+            self.ops.extend(other.ops)
+            return self
+        else:  # And(...) & Or(...)
+            return super().__and__(other)
+
+
+class Or(Q):
+
+    def __init__(self, ops):
+        self.ops = ops
+
+    def compile(self, cls):
+        f = ''
+        for op in self.ops:
+            f += op.compile(cls)
+        return f'(|{f})'
+
+    def __or__(self, other):
+        if type(other) is Q:
+            self.ops.append(other)
+            return self
+        elif type(other) is Or:
+            self.ops.extend(other.ops)
+            return self
+        else:
+            return super().__or__(other)

--- a/ldapper/query.py
+++ b/ldapper/query.py
@@ -1,6 +1,14 @@
-
 class Q(object):
-    """Query class"""
+    """
+    Query class used to build arbitrarily complex query filters.
+
+    Q objects are strung together and then compiled once we are told what the
+    concrete LDAPNode class is going to be.
+
+    The key to the Q class is that it appends conditions when of the same type
+    without creating another level of hierarchy, and it spawns child levels
+    only when the operations (And, Or) switches.
+    """
 
     def __init__(self, **conditions):
         self.conditions = conditions.items()
@@ -12,7 +20,12 @@ class Q(object):
     def compile(self, cls):
         immediate_filter = ''
         for cond_k, cond_v in self.conditions:
-            attrname = cls._fields.get(cond_k).ldap
+            try:
+                attrname = cls._fields.get(cond_k).ldap
+            except AttributeError:
+                raise AttributeError(
+                    f'{cond_k} is not a valid field on {cls.__name__}: '
+                    f'Expected: {list(cls._fields.keys())}')
             immediate_filter += f'({attrname}={cond_v})'
         if len(self.conditions) > 1:
             immediate_filter = f'(&{immediate_filter})'
@@ -39,11 +52,13 @@ class Q(object):
             return immediate_filter
 
     def __and__(self, other):
-        # check that other is of the right type
+        if not isinstance(other, Q):
+            raise TypeError(f'not of type Q: {other}')
         self.AND.append(other)
         return self
 
     def __or__(self, other):
-        # check that other is of the right type
+        if not isinstance(other, Q):
+            raise TypeError(f'not of type Q: {other}')
         self.OR.append(other)
         return self

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+from ldapper.fields import StringField
+from ldapper.query import Q
+
+from .utils import MyLDAPNode
+
+
+class Person(MyLDAPNode):
+    uid = StringField('uid', primary=True)
+    firstname = StringField('givenName', optional=True)
+    lastname = StringField('sn', optional=True)
+
+
+class TestQ:
+
+    def test_one_condition(self):
+        assert Q(firstname='Liam').compile(Person) == '(givenName=Liam)'
+
+    def test_or_conditions(self):
+        qset = Q(firstname='Liam') | Q(lastname='Monahan')
+        assert qset.compile(Person) == '(|(givenName=Liam)(sn=Monahan))'
+
+    def test_or_conditions_same_attr(self):
+        qset = Q(firstname='Liam') | Q(firstname='Bob')
+        assert qset.compile(Person) == '(|(givenName=Liam)(givenName=Bob))'
+
+    def test_and_conditions(self):
+        qset = Q(firstname='Liam') & Q(lastname='Monahan')
+        assert qset.compile(Person) == '(&(givenName=Liam)(sn=Monahan))'
+
+    def test_complex_conditions(self):
+        qset = (Q(firstname='Alice') | Q(firstname='Bob')) & Q(uid='liam')
+        assert qset.compile(Person) == '(&(|(givenName=Alice)(givenName=Bob))(uid=liam))'
+
+    def test_complex_conditions2(self):
+        qset = (
+            (Q(firstname='Alice') | Q(firstname='Bob')) &
+            (Q(uid='liam') | Q(uid='derek'))
+        )
+        assert qset.compile(
+            Person) == '(&(|(givenName=Alice)(givenName=Bob))(|(uid=liam)(uid=derek)))'
+
+    def test_deeply_nested(self):
+        qset = (
+            Q(firstname='Liam') &
+            (Q(lastname='Smith') | (
+                Q(uid='liam') & Q(lastname='Monahan')
+            ))
+        )
+        assert qset.compile(
+            Person) == '(&(givenName=Liam)(|(sn=Smith)(&(uid=liam)(sn=Monahan))))'
+
+    def test_deeply_nested2(self):
+        qset = (
+            Q(firstname='Liam') |
+            (Q(lastname='Smith') & (
+                Q(uid='liam') & Q(lastname='Monahan')
+            ))
+        )
+        assert qset.compile(Person) == \
+            '(|(givenName=Liam)(&(sn=Smith)(&(uid=liam)(sn=Monahan))))'
+
+    def test_deeply_nested3(self):
+        qset = (
+            Q(firstname='Liam') |
+            (Q(lastname='Smith') & (
+                Q(uid='liam') & Q(lastname='Monahan') & Q(firstname='Liam')
+            ))
+        )
+        assert qset.compile(Person) == \
+            '(|(givenName=Liam)(&(sn=Smith)(&(uid=liam)(&(sn=Monahan)(givenName=Liam)))))'
+
+    def test_multi_condition(self):
+        qset = Q(firstname='Liam', lastname='Monahan', uid='liam')
+        assert qset.compile(Person) == '(&(givenName=Liam)(sn=Monahan)(uid=liam))'
+
+    def test_attribute_misspelling(self):
+        pass

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from ldapper.fields import StringField
 from ldapper.query import Q
 
@@ -76,4 +78,11 @@ class TestQ:
         assert qset.compile(Person) == '(&(givenName=Liam)(sn=Monahan)(uid=liam))'
 
     def test_attribute_misspelling(self):
-        pass
+        with pytest.raises(AttributeError):
+            Q(missingattr='foo').compile(Person)
+
+    def test_wrong_type(self):
+        with pytest.raises(TypeError):
+            Q(foo='bar') & 'foobar'
+        with pytest.raises(TypeError):
+            Q(foo='bar') | 'foobar'


### PR DESCRIPTION
This PR adds the ability to filter/list objects based on `Q(...)` statements.  These can be arbitrarily nested.

Note: It would be nice to flatten some statements.  For example we could detect if a statements was only ANDs `(&(sn=Foo)(&(givenName=Bar)(givenName=Baz)))` and squash it to be `(&(sn=Foo)(givenName=Bar)(givenName=Baz))`.  Both are valid filter statements, though.